### PR TITLE
configure minimum release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,6 @@
+# TODO: Add a step to update the version number if needed
+# TODO: Add a step to check correctness of the version number if needed
+
 name: Release
 
 on:
@@ -6,6 +9,8 @@ on:
       - closed
     branches:
       - main
+    paths:
+    - 'package.json'
 
 jobs:
   release:
@@ -31,8 +36,6 @@ jobs:
     - name: Build
       run: npm run build
 
-    # TODO: Add a step to update the version number if needed
-    # TODO: Add a step to check correctness of the version number if needed
     - name: Publish to npm
       run: npm publish
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release Test
+
+on:
+   pull_request:
+    types:
+      - opened
+      - synchronize
+  # pull_request:
+  #   types:
+  #     - closed
+  #   branches:
+  #     - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 'lts/*'
+        registry-url: 'https://registry.npmjs.org'
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Run tests
+      run: npm run test
+
+    - name: Build
+      run: npm run build
+    
+    - name: Show Release Content
+      run: npm pack --dry-run
+
+    # - name: Publish to npm
+    #   run: npm publish
+    #   env:
+    #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,15 @@
-name: Release Test
+name: Release
 
 on:
-   pull_request:
+  pull_request:
     types:
-      - opened
-      - synchronize
-  # pull_request:
-  #   types:
-  #     - closed
-  #   branches:
-  #     - main
+      - closed
+    branches:
+      - main
 
 jobs:
   release:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:
@@ -33,11 +30,10 @@ jobs:
 
     - name: Build
       run: npm run build
-    
-    - name: Show Release Content
-      run: npm pack --dry-run
 
-    # - name: Publish to npm
-    #   run: npm publish
-    #   env:
-    #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    # TODO: Add a step to update the version number if needed
+    # TODO: Add a step to check correctness of the version number if needed
+    - name: Publish to npm
+      run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v3
       with:
         node-version: 'lts/*'
 
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v3
       with:
         node-version: 'lts/*'
 
@@ -53,7 +53,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v3
       with:
         node-version: 'lts/*'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: 'lts/*'
 
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: 'lts/*'
 
@@ -50,10 +50,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: 'lts/*'
 


### PR DESCRIPTION
## Background and Motivation
- Release was previously challenging and prone to make mistakes

## Implementation
- Set up a workflow for automated releases.
  - After this release,  it will be available to manually update the package.json version, and the release will be automated upon PR closure.
    - if there's no  package.json update, release workflow will be skipped
  - The workflow is intentionally minimalistic.
    - Steps will be updated as needed.
- Updated the version of actions in the test workflow.
## Test
- [x] checked that GitHub Actions work correctly with this PR
  - [x] succeeded to build and checked its content with `npm pack --dry-run`
  - [x] `paths` option works correctly when package.json is updated