### PR TITLE
 Refactor cell type handling in minesweeper logic

### DIFF
--- a/src/helpers/cellHelpers.ts
+++ b/src/helpers/cellHelpers.ts
@@ -1,37 +1,38 @@
-import { CellData } from '../logics/board';
+import type {
+  Cell,
+  EmptyContent,
+  ExplodedMineCell,
+  FlaggedState,
+  MineCountContent,
+  OpenedState,
+  UnexplodedMineCell,
+  UnopenedState,
+} from '../logics/board';
 
-export function isMine(
-  cell: CellData,
-): cell is CellData & { content: { type: 'mine'; exploded: boolean } } {
+export function isMine(cell: Cell): cell is UnexplodedMineCell | ExplodedMineCell {
   return cell.content.type === 'mine';
 }
 
-export function isExplodedMine(
-  cell: CellData,
-): cell is CellData & { content: { type: 'mine'; exploded: true } } {
-  return cell.content.type === 'mine' && cell.content.exploded;
+export function isExplodedMine(cell: Cell): cell is ExplodedMineCell {
+  return isMine(cell) && cell.content.exploded;
 }
 
-export function isCount(
-  cell: CellData,
-): cell is CellData & { content: { type: 'count'; value: number } } {
+export function isMineCount(cell: Cell): cell is Cell & { content: MineCountContent } {
   return cell.content.type === 'count';
 }
 
-export function isEmpty(cell: CellData): cell is CellData & { content: { type: 'empty' } } {
+export function isEmpty(cell: Cell): cell is Cell & { content: EmptyContent } {
   return cell.content.type === 'empty';
 }
 
-export function isOpened(cell: CellData): cell is CellData & { state: { type: 'opened' } } {
+export function isOpened(cell: Cell): cell is Cell & { state: OpenedState } {
   return cell.state.type === 'opened';
 }
 
-export function isUnopened(cell: CellData): cell is CellData & { state: { type: 'unopened' } } {
+export function isUnopened(cell: Cell): cell is Cell & { state: UnopenedState } {
   return cell.state.type === 'unopened';
 }
 
-export function isFlagged(cell: CellData): cell is CellData & {
-  state: { type: 'unopened'; flag: 'normal' | 'suspected' };
-} {
+export function isFlagged(cell: Cell): cell is Cell & { state: FlaggedState } {
   return isUnopened(cell) && cell.state.flag !== 'none';
 }

--- a/src/helpers/cellHelpers.ts
+++ b/src/helpers/cellHelpers.ts
@@ -6,6 +6,12 @@ export function isMine(
   return cell.content.type === 'mine';
 }
 
+export function isExplodedMine(
+  cell: CellData,
+): cell is CellData & { content: { type: 'mine'; exploded: true } } {
+  return cell.content.type === 'mine' && cell.content.exploded;
+}
+
 export function isCount(
   cell: CellData,
 ): cell is CellData & { content: { type: 'count'; value: number } } {

--- a/src/hooks/useMinesweeper.ts
+++ b/src/hooks/useMinesweeper.ts
@@ -5,23 +5,22 @@ import {
   countNormalFlags,
   countSuspectedFlags,
   initBoard,
-  isAllOpened,
-  openAll,
   openCell,
   makePlayable,
   switchFlagType,
   toggleFlag,
   PlainBoard,
   PlayableBoard,
-  AllOpenedBoard,
-  ExplodedBoard,
+  CompletedBoard,
+  FailedBoard,
+  isCompletedBoard,
+  isExplodedBoard,
 } from '../logics/board';
-import { isExplodedBoard } from '../logics/board/boardQueries';
 
 interface State {
   gameMode: GameMode;
   gameState: GameState;
-  board: Board;
+  board: Board<any>;
 }
 
 interface InitialState extends State {
@@ -36,12 +35,12 @@ interface PlayingState extends State {
 
 interface CompletedState extends State {
   gameState: 'completed';
-  board: AllOpenedBoard;
+  board: CompletedBoard;
 }
 
 interface FailedState extends State {
   gameState: 'failed';
-  board: ExplodedBoard;
+  board: FailedBoard;
 }
 
 const isInitialState = (state: State | InitialState): state is InitialState => {
@@ -78,14 +77,13 @@ const open = (
 
   if (result.kind === 'Right') {
     const updatedBoard = result.value;
-    if (isAllOpened(updatedBoard)) {
-      return {
-        ...state,
-        gameState: 'completed',
-        board: openAll(updatedBoard),
-      };
-    }
-    return { ...state, gameState: 'playing', board: updatedBoard };
+    return isCompletedBoard(updatedBoard)
+      ? {
+          ...state,
+          gameState: 'completed',
+          board: updatedBoard,
+        }
+      : { ...state, gameState: 'playing', board: updatedBoard };
   } else {
     const invalidBoard = result.value;
     if (isExplodedBoard(invalidBoard)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,17 @@ export { useMinesweeper } from './hooks/useMinesweeper';
 export { GAME_MODE_LIST } from './logics/game';
 
 // helpers
-export { isMine, isCount, isEmpty, isOpened, isUnopened, isFlagged } from './helpers/cellHelpers';
+export {
+  isMine,
+  // isExplodedMine,
+  isMineCount as isCount,
+  isEmpty,
+  isOpened,
+  isUnopened,
+  isFlagged,
+} from './helpers/cellHelpers';
 
 // types
 export type { Minesweeper } from './hooks/useMinesweeper';
 export type { GameMode } from './logics/game';
-export type { Board, BoardConfig, CellData } from './logics/board';
+export type { Board, BoardConfig, Cell as CellData } from './logics/board';

--- a/src/logics/board/boardActions.ts
+++ b/src/logics/board/boardActions.ts
@@ -1,17 +1,17 @@
-import { AllOpenedBoard, Board, CellData, ExplodedBoard, ExplodedCellData, PlayableBoard } from '.';
+import { Cell, CompletedBoard, EmptyContent, FailedBoard, MineCountContent, PlayableBoard, PlayableCell, SafeCell, UnopenedState } from '.';
 import { isOpened, isEmpty, isMine, isUnopened } from '../../helpers/cellHelpers';
 
 import { Either } from '../../types/either';
 import { getAroundItems, toMarixPosition, isInside } from '../../utils/matrix';
 
-const open = (board: PlayableBoard, selected: [number, number]): PlayableBoard | AllOpenedBoard => {
+const open = (board: PlayableBoard, targetCell: SafeCell & {state: UnopenedState}): PlayableBoard | CompletedBoard => {
   // 指定されたboardのマスを開く
   return {
     ...board,
-    data: board.data.map((row, i) => {
-      return row.map((cell, j) => {
-        if (i === selected[0] && j === selected[1]) {
-          return { ...cell, state: { type: 'opened' } };
+    data: board.data.map((row) => {
+      return row.map((cell) => {
+        if (cell.id !== targetCell.id) {
+          return { ...targetCell, state: { type: 'opened' } };
         }
         return cell;
       });
@@ -22,26 +22,29 @@ const open = (board: PlayableBoard, selected: [number, number]): PlayableBoard |
 // 何もないマスを一括開放する
 const openEmptyArea = (
   board: PlayableBoard,
-  selected: [number, number],
-): PlayableBoard | AllOpenedBoard => {
+  targetCell: Cell & { content: EmptyContent; state: UnopenedState },
+): PlayableBoard | CompletedBoard => {
   // flood fill
   // はじめはキューで実装していたが、Array.shift()がO(n)なので遅いためスタックで実装
-  let stack = [selected];
+  let stack = [toMarixPosition(targetCell.id, board.meta.cols)];
   // 同じマスを何度も開かないようにするためにSetを使う
-  let checkList = new Set<CellData['id']>();
+  let checkList = new Set<Cell['id']>();
 
-  let newBoard = board;
+  let newBoard: PlayableBoard | CompletedBoard = board;
 
   // TODO: 効率化
   while (stack.length > 0) {
     const target = stack.pop() as [number, number];
 
-    newBoard = open(newBoard, target);
+    newBoard = open(
+      newBoard as PlayableBoard,
+      newBoard.data[target[0]][target[1]] as SafeCell & { state: UnopenedState },
+    );
 
     if (!isEmpty(newBoard.data[target[0]][target[1]])) continue;
 
     // 何もないマスだったら周囲のマスをキューに追加
-    getAroundItems(newBoard.data, target)
+    getAroundItems(newBoard.data as PlayableCell[][], target)
       .filter((cell) => !isOpened(cell) && !isMine(cell))
       .filter((cell) => !checkList.has(cell.id))
       .forEach((cell) => {
@@ -56,7 +59,7 @@ const openEmptyArea = (
 export const openCell = (
   board: PlayableBoard,
   cellId: number,
-): Either<PlayableBoard | ExplodedBoard, PlayableBoard | AllOpenedBoard> => {
+): Either<PlayableBoard | FailedBoard, PlayableBoard | CompletedBoard> => {
   const position = toMarixPosition(cellId, board.meta.cols);
 
   const targetCell = board.data[position[0]][position[1]];
@@ -66,16 +69,19 @@ export const openCell = (
   }
 
   if (isMine(targetCell)) {
-    return { kind: 'Left', value: igniteMines(openAll(board)) };
+    return { kind: 'Left', value: igniteMines(board) };
   }
 
   // result of checks above, targetCell is unopened and not mine
-  const updatedBoard = isEmpty(targetCell) ? openEmptyArea(board, position) : open(board, position);
+  // targetCellがSafeCell & { state: UnopenedState }であることをTypeScriptに伝える
+  const updatedBoard = isEmpty(targetCell)
+    ? openEmptyArea(board, targetCell as typeof targetCell & { state: UnopenedState })
+    : open(board, targetCell as typeof targetCell & { state: UnopenedState });
 
   return { kind: 'Right', value: updatedBoard };
 };
 
-export const openAll = (board: PlayableBoard): AllOpenedBoard => {
+export const openAll = (board: PlayableBoard): CompletedBoard => {
   return {
     ...board,
     data: board.data.map((row) => {
@@ -86,10 +92,11 @@ export const openAll = (board: PlayableBoard): AllOpenedBoard => {
   };
 };
 
-export const igniteMines = (board: AllOpenedBoard): ExplodedBoard => {
+export const igniteMines = (board: PlayableBoard): FailedBoard => {
+  const openedBoard = openAll(board);
   return {
-    ...board,
-    data: board.data.map((row) => {
+    ...openedBoard,
+    data: openedBoard.data.map((row) => {
       return row.map((cell) => {
         return isMine(cell) ? { ...cell, content: { ...cell.content, exploded: true } } : cell;
       });

--- a/src/logics/board/boardActions.ts
+++ b/src/logics/board/boardActions.ts
@@ -1,10 +1,23 @@
-import { Cell, CompletedBoard, EmptyContent, FailedBoard, MineCountContent, PlayableBoard, PlayableCell, SafeCell, UnopenedState } from '.';
+import {
+  Cell,
+  CompletedBoard,
+  EmptyContent,
+  FailedBoard,
+  PlayableBoard,
+  PlayableCell,
+  SafeCell,
+  UnopenedState,
+  isOnlyMinesLeft,
+} from '.';
 import { isOpened, isEmpty, isMine, isUnopened } from '../../helpers/cellHelpers';
 
 import { Either } from '../../types/either';
 import { getAroundItems, toMarixPosition, isInside } from '../../utils/matrix';
 
-const open = (board: PlayableBoard, targetCell: SafeCell & {state: UnopenedState}): PlayableBoard | CompletedBoard => {
+const open = (
+  board: PlayableBoard,
+  targetCell: SafeCell & { state: UnopenedState },
+): PlayableBoard => {
   // 指定されたboardのマスを開く
   return {
     ...board,
@@ -23,14 +36,14 @@ const open = (board: PlayableBoard, targetCell: SafeCell & {state: UnopenedState
 const openEmptyArea = (
   board: PlayableBoard,
   targetCell: Cell & { content: EmptyContent; state: UnopenedState },
-): PlayableBoard | CompletedBoard => {
+): PlayableBoard => {
   // flood fill
   // はじめはキューで実装していたが、Array.shift()がO(n)なので遅いためスタックで実装
   let stack = [toMarixPosition(targetCell.id, board.meta.cols)];
   // 同じマスを何度も開かないようにするためにSetを使う
   let checkList = new Set<Cell['id']>();
 
-  let newBoard: PlayableBoard | CompletedBoard = board;
+  let newBoard = board;
 
   // TODO: 効率化
   while (stack.length > 0) {
@@ -78,7 +91,9 @@ export const openCell = (
     ? openEmptyArea(board, targetCell as typeof targetCell & { state: UnopenedState })
     : open(board, targetCell as typeof targetCell & { state: UnopenedState });
 
-  return { kind: 'Right', value: updatedBoard };
+  return isOnlyMinesLeft(updatedBoard)
+    ? { kind: 'Right', value: openAll(updatedBoard) }
+    : { kind: 'Right', value: updatedBoard };
 };
 
 export const openAll = (board: PlayableBoard): CompletedBoard => {

--- a/src/logics/board/boardInitializers.ts
+++ b/src/logics/board/boardInitializers.ts
@@ -1,11 +1,4 @@
-import {
-  BoardConfig,
-  CellData,
-  PlainBoard,
-  PlayableCellData,
-  PlainCellData,
-  PlayableBoard,
-} from '.';
+import { BoardConfig, CellData, PlainBoard, PlainCellData, PlayableBoard } from '.';
 import { isMine } from '../../helpers/cellHelpers';
 import { convertToMatrix, getAroundItems, toMarixPosition } from '../../utils/matrix';
 import { getRandomElements } from '../../utils/random';
@@ -72,7 +65,7 @@ interface PlainBoardWithMines extends Omit<PlainBoard, 'data'> {
 // 周囲の爆弾の数を数える
 const setMineCount = (board: PlainBoardWithMines): PlayableBoard => {
   // matrixの要素を一つずつ見ていく
-  const newBoardData: PlayableCellData[][] = board.data.map((row, i) => {
+  const newBoardData: PlayableBoard['data'] = board.data.map((row, i) => {
     return row.map((cell, j) => {
       // 爆弾だったら何もしない
       if (isMine(cell)) return cell;

--- a/src/logics/board/boardInitializers.ts
+++ b/src/logics/board/boardInitializers.ts
@@ -1,4 +1,12 @@
-import { BoardConfig, CellData, PlainBoard, PlainCellData, PlayableBoard } from '.';
+import {
+  Board,
+  BoardConfig,
+  Cell,
+  PlainBoard,
+  PlainCell,
+  PlayableBoard,
+  UnexplodedMineCell,
+} from '.';
 import { isMine } from '../../helpers/cellHelpers';
 import { convertToMatrix, getAroundItems, toMarixPosition } from '../../utils/matrix';
 import { getRandomElements } from '../../utils/random';
@@ -9,7 +17,7 @@ export const initBoard = (config: BoardConfig): PlainBoard => {
 
 const makePlainBoard = (config: BoardConfig): PlainBoard => {
   const { rows, cols } = config;
-  const plainBoardData: PlainCellData[] = [...Array(rows * cols)].map((_, i) => {
+  const plainBoardData: PlainCell[] = [...Array(rows * cols)].map((_, i) => {
     return {
       id: i,
       content: { type: 'empty' },
@@ -25,7 +33,7 @@ const makePlainBoard = (config: BoardConfig): PlainBoard => {
 
 export const makePlayable = (
   board: PlainBoard,
-  forceEmpty: CellData['id'] | undefined = undefined,
+  forceEmpty: Cell['id'] | undefined = undefined,
 ): PlayableBoard => {
   // initialBoardの中からランダムにmines個の爆弾の位置を決める
   // forceEmptyが指定されている場合はそのマスと周囲のマスを除外する
@@ -58,9 +66,7 @@ export const makePlayable = (
 };
 
 // mine-added plain board(without mine count)
-interface PlainBoardWithMines extends Omit<PlainBoard, 'data'> {
-  data: Array<Array<PlainCellData | (CellData & { content: { type: 'mine'; exploded: false } })>>;
-}
+type PlainBoardWithMines = Board<PlainCell | UnexplodedMineCell>;
 
 // 周囲の爆弾の数を数える
 const setMineCount = (board: PlainBoardWithMines): PlayableBoard => {

--- a/src/logics/board/boardQueries.ts
+++ b/src/logics/board/boardQueries.ts
@@ -1,9 +1,15 @@
-import { Board } from '.';
-import { isMine, isOpened, isFlagged } from '../../helpers/cellHelpers';
+import { AllOpenedBoard, Board, ExplodedBoard, PlayableBoard } from '.';
+import { isMine, isOpened, isFlagged, isExplodedMine } from '../../helpers/cellHelpers';
 
-export const isAllOpened = (board: Board): boolean => {
+export const isAllOpened = (board: PlayableBoard | AllOpenedBoard): board is AllOpenedBoard => {
   return board.data.flat().every((cell) => {
     return isMine(cell) || isOpened(cell); // 爆弾以外のマスが全て開いていたら勝利
+  });
+};
+
+export const isExplodedBoard = (board: PlayableBoard | ExplodedBoard): board is ExplodedBoard => {
+  return board.data.flat().every((cell) => {
+    return isExplodedMine(cell);
   });
 };
 

--- a/src/logics/board/boardQueries.ts
+++ b/src/logics/board/boardQueries.ts
@@ -1,9 +1,17 @@
-import { Board, Cell, CompletedBoard, FailedBoard, FlaggedState, PlainBoard, PlayableBoard } from '.';
+import { Cell, CompletedBoard, FailedBoard, FlaggedState, PlainBoard, PlayableBoard } from '.';
 import { isMine, isOpened, isFlagged, isExplodedMine } from '../../helpers/cellHelpers';
 
-export const isAllOpened = (board: PlayableBoard | CompletedBoard): board is CompletedBoard => {
+export const isOnlyMinesLeft = (board: PlayableBoard): boolean => {
   return board.data.flat().every((cell) => {
-    return isMine(cell) || isOpened(cell); // 爆弾以外のマスが全て開いていたら勝利
+    return (isMine(cell) && !isOpened(cell)) || isOpened(cell); // 爆弾以外のマスが全て開いていたら勝利
+  });
+};
+
+export const isCompletedBoard = (
+  board: PlayableBoard | CompletedBoard,
+): board is CompletedBoard => {
+  return board.data.flat().every((cell) => {
+    return !isExplodedMine(cell) && isOpened(cell);
   });
 };
 

--- a/src/logics/board/boardQueries.ts
+++ b/src/logics/board/boardQueries.ts
@@ -1,22 +1,23 @@
-import { AllOpenedBoard, Board, ExplodedBoard, PlayableBoard } from '.';
+import { Board, Cell, CompletedBoard, FailedBoard, FlaggedState, PlainBoard, PlayableBoard } from '.';
 import { isMine, isOpened, isFlagged, isExplodedMine } from '../../helpers/cellHelpers';
 
-export const isAllOpened = (board: PlayableBoard | AllOpenedBoard): board is AllOpenedBoard => {
+export const isAllOpened = (board: PlayableBoard | CompletedBoard): board is CompletedBoard => {
   return board.data.flat().every((cell) => {
     return isMine(cell) || isOpened(cell); // 爆弾以外のマスが全て開いていたら勝利
   });
 };
 
-export const isExplodedBoard = (board: PlayableBoard | ExplodedBoard): board is ExplodedBoard => {
+export const isExplodedBoard = (board: PlayableBoard | FailedBoard): board is FailedBoard => {
   return board.data.flat().every((cell) => {
     return isExplodedMine(cell);
   });
 };
 
-const filterFlaggedCells = (board: Board) => board.data.flat().filter(isFlagged);
+const filterFlaggedCells = (board: PlainBoard | PlayableBoard) =>
+  board.data.flat().filter(isFlagged) as (Cell & { state: FlaggedState })[];
 
-export const countNormalFlags = (board: Board) =>
+export const countNormalFlags = (board: PlainBoard | PlayableBoard) =>
   filterFlaggedCells(board).filter((cell) => cell.state.flag === 'normal').length;
 
-export const countSuspectedFlags = (board: Board) =>
+export const countSuspectedFlags = (board: PlainBoard | PlayableBoard) =>
   filterFlaggedCells(board).filter((cell) => cell.state.flag === 'suspected').length;

--- a/src/logics/board/index.ts
+++ b/src/logics/board/index.ts
@@ -3,5 +3,5 @@ export type * from './types';
 
 // functions
 export { openCell, openAll, igniteMines, toggleFlag, switchFlagType } from './boardActions';
-export { initBoard, setMines } from './boardInitializers';
+export { initBoard, makePlayable } from './boardInitializers';
 export { isAllOpened, countNormalFlags, countSuspectedFlags } from './boardQueries';

--- a/src/logics/board/index.ts
+++ b/src/logics/board/index.ts
@@ -4,4 +4,10 @@ export type * from './types';
 // functions
 export { openCell, openAll, igniteMines, toggleFlag, switchFlagType } from './boardActions';
 export { initBoard, makePlayable } from './boardInitializers';
-export { isAllOpened, countNormalFlags, countSuspectedFlags } from './boardQueries';
+export {
+  isOnlyMinesLeft,
+  isCompletedBoard,
+  isExplodedBoard,
+  countNormalFlags,
+  countSuspectedFlags,
+} from './boardQueries';

--- a/src/logics/board/types.ts
+++ b/src/logics/board/types.ts
@@ -9,9 +9,8 @@ export type Board<T> = {
   data: T[][];
 };
 
-export type CellState =
-  | { type: 'opened' }
-  | { type: 'unopened'; flag: 'normal' | 'suspected' | 'none' };
+export type CellState = { type: 'opened' } | { type: 'unopened'; flag: FlagValue };
+type FlagValue = 'normal' | 'suspected' | 'none';
 
 export type CellContent =
   | { type: 'mine'; exploded: boolean }
@@ -31,8 +30,8 @@ export type ExplodedMineContent = { type: 'mine'; exploded: true };
 export type MineCountContent = { type: 'count'; value: number };
 
 // Specific Cell State Types
-export type UnopenedState = { type: 'unopened'; flag: 'normal' | 'suspected' | 'none' };
-export type FlaggedState = Exclude<UnopenedState, { flag: 'none' }>;
+export type UnopenedState = { type: 'unopened'; flag: FlagValue };
+export type FlaggedState = { type: 'unopened'; flag: Exclude<FlagValue, 'none'> };
 export type OpenedState = { type: 'opened' };
 
 // Specific Cell Types
@@ -47,7 +46,7 @@ export type UnexplodedMineCell = Cell & {
   state: UnopenedState;
 };
 // contents which can be opened
-type SafeCell = Cell & {
+export type SafeCell = Cell & {
   content: Exclude<CellContent, { type: 'mine' }>;
   state: UnopenedState | OpenedState;
 };

--- a/src/logics/board/types.ts
+++ b/src/logics/board/types.ts
@@ -28,10 +28,11 @@ export type Cell = {
 export type EmptyContent = { type: 'empty' };
 export type UnexplodedMineContent = { type: 'mine'; exploded: false };
 export type ExplodedMineContent = { type: 'mine'; exploded: true };
-export type CountContent = { type: 'count'; value: number };
+export type MineCountContent = { type: 'count'; value: number };
 
 // Specific Cell State Types
 export type UnopenedState = { type: 'unopened'; flag: 'normal' | 'suspected' | 'none' };
+export type FlaggedState = Exclude<UnopenedState, { flag: 'none' }>;
 export type OpenedState = { type: 'opened' };
 
 // Specific Cell Types
@@ -41,7 +42,7 @@ export type PlainCell = Cell & {
   state: UnopenedState;
 };
 // mine must be unopened while playing
-type UntouchableCell = Cell & {
+export type UnexplodedMineCell = Cell & {
   content: UnexplodedMineContent;
   state: UnopenedState;
 };
@@ -51,7 +52,7 @@ type SafeCell = Cell & {
   state: UnopenedState | OpenedState;
 };
 // Varieties of cells which appear on the board while playing
-export type PlayableCell = UntouchableCell | SafeCell;
+export type PlayableCell = UnexplodedMineCell | SafeCell;
 
 export type ExplodedMineCell = Cell & {
   content: ExplodedMineContent;

--- a/src/logics/board/types.ts
+++ b/src/logics/board/types.ts
@@ -11,6 +11,14 @@ export interface PlayableBoard extends Board {
   data: PlayableCellData[][];
 }
 
+export interface AllOpenedBoard extends Board {
+  data: AllOpenedCellData[][];
+}
+
+export interface ExplodedBoard extends Board {
+  data: (ExplodedCellData | AllOpenedCellData)[][];
+}
+
 export type BoardConfig = {
   rows: number;
   cols: number;
@@ -35,4 +43,17 @@ export interface PlayableCellData extends Omit<CellData, 'content'> {
   content:
     | { type: 'mine'; exploded: false } // [changed] exploded: boolean -> exploded: false
     | Exclude<CellData['content'], { type: 'mine'; exploded: boolean }>;
+}
+
+// all cells are opened and mines are not exploded
+export interface AllOpenedCellData extends PlayableCellData {
+  state: { type: 'opened' };
+}
+
+// all cells are opened and mines are exploded
+export interface ExplodedCellData extends Omit<CellData, 'content'> {
+  content:
+    | { type: 'mine'; exploded: true } // [changed] exploded: boolean -> exploded: true
+    | Exclude<CellData['content'], { type: 'mine'; exploded: boolean }>;
+  state: { type: 'opened' };
 }

--- a/src/logics/board/types.ts
+++ b/src/logics/board/types.ts
@@ -1,7 +1,15 @@
-export type Board = {
+export interface Board {
   meta: BoardConfig;
   data: CellData[][];
-};
+}
+
+export interface PlainBoard extends Board {
+  data: PlainCellData[][];
+}
+
+export interface PlayableBoard extends Board {
+  data: PlayableCellData[][];
+}
 
 export type BoardConfig = {
   rows: number;
@@ -9,11 +17,22 @@ export type BoardConfig = {
   mines: number;
 };
 
-export type CellData = {
+export interface CellData {
   id: number;
   content:
     | { type: 'mine'; exploded: boolean }
     | { type: 'count'; value: number }
     | { type: 'empty' };
   state: { type: 'opened' } | { type: 'unopened'; flag: 'normal' | 'suspected' | 'none' };
-};
+}
+
+export interface PlainCellData extends CellData {
+  content: { type: 'empty' };
+  state: { type: 'unopened'; flag: 'none' };
+}
+
+export interface PlayableCellData extends Omit<CellData, 'content'> {
+  content:
+    | { type: 'mine'; exploded: false } // [changed] exploded: boolean -> exploded: false
+    | Exclude<CellData['content'], { type: 'mine'; exploded: boolean }>;
+}


### PR DESCRIPTION
## Background and Motivation
- The existing Minesweeper logic had a lack of type safety when handling different cell states
- The goal of this PR is to enhance type safety by leveraging TypeScript's advanced type features

## Implementation
-  Introduced distinct cell types (`SafeCell`, `EmptyCell`, etc.) to represent different cell states.
- Introduced distinct game state types to represent different game states.

## Test
- [x] installed to local `ebinase/minesweeper` repo using `npm link` and checked to work
