### PR TITLE
[Hotfix] v0.2.5 fix the issue to open all cells on click

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ebinas/react-use-minesweeper",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ebinas/react-use-minesweeper",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "react": "18.2.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ebinas/react-use-minesweeper",
   "description": "A simple react hook for minesweeper",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "license": "MIT",
   "author": "ebinas",
   "main": "./dist/index.js",

--- a/src/logics/board/boardActions.ts
+++ b/src/logics/board/boardActions.ts
@@ -23,7 +23,7 @@ const open = (
     ...board,
     data: board.data.map((row) => {
       return row.map((cell) => {
-        if (cell.id !== targetCell.id) {
+        if (cell.id === targetCell.id) {
           return { ...targetCell, state: { type: 'opened' } };
         }
         return cell;


### PR DESCRIPTION
## Background and Motivation
- using v0.2.4, all cells except clicked one are opened 
  - #7 
- couldn't notice this problem because of wrong usage of `npm link`

## Implementation
- the conditional expression in `open()` was reversed, and fixed it

## Test
- [x] installed to local ebinase/minesweeper repo using `npm link` and confirmed to work
