### PR TITLE
Update release flow to run only on release branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,11 @@ on:
     branches:
       - main
     paths:
-    - 'package.json'
+      - 'package.json'
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'release'
     runs-on: ubuntu-latest
 
     steps:
@@ -40,3 +40,8 @@ jobs:
       run: npm publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: Delete release branch
+      run: git push origin --delete release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Background and Motivation
- prevent unexpected release flow execution
- explicitly set release branch
## Implementation
-  make release workflow to run only on `release` branch
- delete `release` branch after release

## Test
