### PR TITLE
fix isExplodedBoard logic

### DIFF
--- a/src/logics/board/boardQueries.ts
+++ b/src/logics/board/boardQueries.ts
@@ -16,7 +16,7 @@ export const isCompletedBoard = (
 };
 
 export const isExplodedBoard = (board: PlayableBoard | FailedBoard): board is FailedBoard => {
-  return board.data.flat().every((cell) => {
+  return board.data.flat().some((cell) => {
     return isExplodedMine(cell);
   });
 };


### PR DESCRIPTION
## Background and Motivation
- there's a problem that game state doesn't turn  into `failed` when click mine

## Implementation
- fixed `isExplodedBoard` which detect whether the mines are exploded or not

## Test
- [x] installed to local ebinase/minesweeper repo using npm link and confirmed to work
