### PR TITLE
Disable release branch deletion on workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,3 @@ jobs:
       run: npm publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-    - name: Delete release branch
-      run: git push origin --delete release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Background and Motivation
- release was failed because of branch deletion workflow 
  - https://github.com/ebinase/react-use-minesweeper/actions/runs/6518650501
- in the future, fix this problem with using personal access token(not now)

## Implementation
- removed release branch deletion on workflow

## Test
- [ ] check
